### PR TITLE
Rectify parameters passed to strsep to avoid error EINVAL

### DIFF
--- a/recipes-kernel/rpsmg-sdb-mod/files/stm32_rpmsg_sdb.c
+++ b/recipes-kernel/rpsmg-sdb-mod/files/stm32_rpmsg_sdb.c
@@ -77,7 +77,8 @@ static long rpmsg_sdb_decode_rxbuf_string(char *rxbuf_str, int *buffer_id, size_
 	char *sub_str;
 	long bsize;
 	long bufid;
-	const char delimiter[1] = {'L'};
+	//const char delimiter[1] = {'L'};
+	const char delimiter[] = "L";
 
 	pr_debug("rpmsg_sdb(%s): rxbuf_str:%s\n", __func__, rxbuf_str);
 


### PR DESCRIPTION
Function strcspn & strsep expects a null terminated string delimiter in this case so as to avoid corruption
This issue is observed with example incoming string B0L0000000C passed to rpmsg_sdb_decode_rxbuf_string
With delimiter set to {'L'} and not null terminated, whereas the function strcspn expects a null terminated string
This will result in delimiter with garbage value getting passed eventually resulting in EINVAL issue observed specifically in case of B0 as observed below
incoming string [B0L0000000C]  rxbuf_str string [L0000000C] and subString is [B]